### PR TITLE
change variable name ret to res

### DIFF
--- a/R/test-single-val.R
+++ b/R/test-single-val.R
@@ -126,7 +126,7 @@ test_single_length.autotest_obj <- function (x, val_type, test_data = NULL) { # 
     if (!is.null (test_data)) {
         x$test <- test_these_data (test_data, res)
         if (!x$test)
-            ret$type <- "no_test"
+            res$type <- "no_test"
     }
 
     if (x$test) {


### PR DESCRIPTION
Fixed a likely copy-paste error which caused an error "ret not found" when supplied `test_data` set `autotest_single` test to FALSE.