### PR TITLE
fix test_double noise test flag for #53

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: autotest
 Title: Automatic Package Testing
-Version: 0.0.2.159
+Version: 0.0.2.160
 Authors@R: 
     c(person(given = "Mark",
              family = "Padgham",

--- a/R/input-double.R
+++ b/R/input-double.R
@@ -82,17 +82,22 @@ test_double_noise.autotest_obj <- function (x, test_data = NULL, ...) {
 
     res <- NULL
 
+    test_data_off <- FALSE
+
     if (!is.null (test_data)) {
         r <- test_double_noise.NULL ()
         x$test <- test_these_data (test_data, r)
         if (!x$test)
-            res$type <- "no_test"
+            test_data_off <- TRUE
     }
 
     if (x$test)
         res <- double_noise (x)
     else
         res <- dbl_noise_dummy_report (x)
+
+    if (test_data_off)
+        res$type <- "no_test"
 
     return (res)
 }

--- a/R/input-double.R
+++ b/R/input-double.R
@@ -15,17 +15,22 @@ test_double_is_int.autotest_obj <- function (x, test_data = NULL, ...) { # nolin
 
     res <- NULL
 
+    test_data_off <- FALSE
+
     if (!is.null (test_data)) {
         r <- test_double_is_int.NULL ()
         x$test <- test_these_data (test_data, r)
         if (!x$test)
-            res$type <- "no_test"
+            test_data_off <- TRUE
     }
 
     if (x$test)
         res <- double_is_int (x)
     else
         res <- dbl_is_int_dummy_report (x)
+
+    if (test_data_off)
+        res$type <- "no_test"
 
     return (res)
 }

--- a/R/input-double.R
+++ b/R/input-double.R
@@ -15,13 +15,9 @@ test_double_is_int.autotest_obj <- function (x, test_data = NULL, ...) { # nolin
 
     res <- NULL
 
-    test_data_off <- FALSE
-
     if (!is.null (test_data)) {
         r <- test_double_is_int.NULL ()
         x$test <- test_these_data (test_data, r)
-        if (!x$test)
-            test_data_off <- TRUE
     }
 
     if (x$test)
@@ -29,7 +25,7 @@ test_double_is_int.autotest_obj <- function (x, test_data = NULL, ...) { # nolin
     else
         res <- dbl_is_int_dummy_report (x)
 
-    if (test_data_off)
+    if (!is.null (test_data) & !x$test & !is.null (res))
         res$type <- "no_test"
 
     return (res)
@@ -87,13 +83,9 @@ test_double_noise.autotest_obj <- function (x, test_data = NULL, ...) {
 
     res <- NULL
 
-    test_data_off <- FALSE
-
     if (!is.null (test_data)) {
         r <- test_double_noise.NULL ()
         x$test <- test_these_data (test_data, r)
-        if (!x$test)
-            test_data_off <- TRUE
     }
 
     if (x$test)
@@ -101,7 +93,7 @@ test_double_noise.autotest_obj <- function (x, test_data = NULL, ...) {
     else
         res <- dbl_noise_dummy_report (x)
 
-    if (test_data_off)
+    if (!is.null (test_data) & !x$test & !is.null (res))
         res$type <- "no_test"
 
     return (res)

--- a/R/input-int.R
+++ b/R/input-int.R
@@ -37,14 +37,15 @@ test_single_int_range.autotest_obj <- function (x, test_data = NULL, ...) { # no
         # These two tests are coupled, with `test` flags determined by the
         # first only
         x$test <- test_these_data (test_data, r)
-        if (!x$test)
-            res$type <- "no_test"
     }
 
     if (x$test)
         res <- single_int_range (x)
     else
         res <- single_int_dummy_report (x)
+
+    if (!is.null (test_data) & !x$test & !is.null (res))
+        res$type <- "no_test"
 
     return (res)
 }
@@ -288,6 +289,7 @@ test_int_as_dbl.autotest_obj <- function (x, vec = FALSE, test_data = NULL) { # 
     }
 
     if (x$test) {
+
         f <- tempfile (fileext = ".txt")
         out1 <- catch_all_msgs (f, x$fn, x$params)
 

--- a/R/input-name.R
+++ b/R/input-name.R
@@ -13,19 +13,19 @@ test_single_name.NULL <- function (x = NULL, ...) {
 
 test_single_name.autotest_obj <- function (x, test_data = NULL) {
 
-    ret <- test_single_name.NULL ()
+    res <- test_single_name.NULL ()
 
-    ret$fn_name <- x$fn
-    ret$parameter <- names (x$params) [x$i]
+    res$fn_name <- x$fn
+    res$parameter <- names (x$params) [x$i]
 
-    ret$operation <- paste0 ("(unquoted) ",
+    res$operation <- paste0 ("(unquoted) ",
                              class (x$params [[x$i]]) [1],
                              " param as (quoted) character")
 
     if (!is.null (test_data)) {
-        x$test <- test_these_data (test_data, ret)
+        x$test <- test_these_data (test_data, res)
         if (!x$test)
-            ret$type <- "no_test"
+            res$type <- "no_test"
     }
 
     if (x$test) {
@@ -35,12 +35,12 @@ test_single_name.autotest_obj <- function (x, test_data = NULL) {
         x$params [[x$i]] <- as.character (x$params [[x$i]])
         msgs <- catch_all_msgs (f, x$fn, x$params)
         if (!is.null (msgs)) {
-            ret$type <- msgs$type
-            ret$content <- msgs$content
+            res$type <- msgs$type
+            res$content <- msgs$content
         } else {
-            ret <- NULL
+            res <- NULL
         }
     }
 
-    return (ret)
+    return (res)
 }

--- a/codemeta.json
+++ b/codemeta.json
@@ -10,7 +10,7 @@
   "codeRepository": "https://github.com/ropensci-review-tools/autotest",
   "issueTracker": "https://github.com/ropensci-review-tools/autotest/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.0.2.159",
+  "version": "0.0.2.160",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",


### PR DESCRIPTION
@helske The initial commit here illustrates how i rectified one of the cases. That one is obvious once you see it - that function re-generated `res` directly from `dbl_noise_dummy_report`, so with `test = "dummy"`, and did not re-insert the `test$type <- "no_test"` line. Feel free to contribute any more that you find.