### PR TITLE
check for line breaks when extracting package deps

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,8 @@ Version: 0.0.2.169
 Authors@R: c(
     person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2172-5265")),
-    person("Jouni", "Helske", role = "ctb")
+    person("Jouni", "Helske", role = "ctb"),
+    comment = c(ORCID = "0000-0001-7130-793X")
   )
 Description: Automatic testing of R packages via a simple YAML schema.
 License: GPL-3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,8 +4,8 @@ Version: 0.0.2.169
 Authors@R: c(
     person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2172-5265")),
-    person("Jouni", "Helske", role = "ctb"),
-    comment = c(ORCID = "0000-0001-7130-793X")
+    person("Jouni", "Helske", role = "ctb",
+    comment = c(ORCID = "0000-0001-7130-793X"))
   )
 Description: Automatic testing of R packages via a simple YAML schema.
 License: GPL-3

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -162,16 +162,14 @@ get_pkg_deps <- function (pkg, suggests = FALSE) {
             ip <- data.frame (utils::installed.packages (lib.loc = lib),
                               stringsAsFactors = FALSE)
         }
-        deps <- strsplit (ip$Depends [ip$Package == pkg], ",|, ") [[1]]
+        deps <- strsplit (ip$Depends [ip$Package == pkg], ",(\\s?)") [[1]]
         deps <- gsub ("\\s*\\(.*$", "", deps [!is.na (deps)])
-        imports <- strsplit (ip$Imports [ip$Package == pkg], ",|, ") [[1]]
+        imports <- strsplit (ip$Imports [ip$Package == pkg], ",(\\s?)") [[1]]
         deps <- c (deps, gsub ("\\s*\\(.*$", "", imports [!is.na (imports)]))
         if (suggests) {
-          s <- strsplit (ip$Suggests [ip$Package == pkg], ",|, ") [[1]]
-          deps <- c (deps, gsub ("\\s*\\(.*$", "", s [!is.na (s)]))
+            s <- strsplit (ip$Suggests [ip$Package == pkg], ",(\\s?)") [[1]]
+            deps <- c (deps, gsub ("\\s*\\(.*$", "", s [!is.na (s)]))
         }
-        deps <- gsub("[\r\n]", "", deps)
-        
     }
     base_pkgs <- c ("stats", "graphics", "grDevices", "utils",
                     "datasets", "methods", "base")

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -162,15 +162,16 @@ get_pkg_deps <- function (pkg, suggests = FALSE) {
             ip <- data.frame (utils::installed.packages (lib.loc = lib),
                               stringsAsFactors = FALSE)
         }
-
-        deps <- strsplit (ip$Depends [ip$Package == pkg], ", ") [[1]]
+        deps <- strsplit (ip$Depends [ip$Package == pkg], ",|, ") [[1]]
         deps <- gsub ("\\s*\\(.*$", "", deps [!is.na (deps)])
-        imports <- strsplit (ip$Imports [ip$Package == pkg], ", ") [[1]]
+        imports <- strsplit (ip$Imports [ip$Package == pkg], ",|, ") [[1]]
         deps <- c (deps, gsub ("\\s*\\(.*$", "", imports [!is.na (imports)]))
         if (suggests) {
-            s <- strsplit (ip$Suggests [ip$Package == pkg], ", ") [[1]]
-            deps <- c (deps, gsub ("\\s*\\(.*$", "", s [!is.na (s)]))
+          s <- strsplit (ip$Suggests [ip$Package == pkg], ",|, ") [[1]]
+          deps <- c (deps, gsub ("\\s*\\(.*$", "", s [!is.na (s)]))
         }
+        deps <- gsub("[\r\n]", "", deps)
+        
     }
     base_pkgs <- c ("stats", "graphics", "grDevices", "utils",
                     "datasets", "methods", "base")


### PR DESCRIPTION
When using `autotest_package(package = "pkg_name", functions = "fn_name")` the package dependencies are checked from the loaded package, and this seemed to fail if packages were listed with line breaks, e.g.,
```
xf <- autotest_package(package = "bssm", functions = "asymptotic_var")
Error in library(p, character.only = TRUE) : 
  there is no package called ‘magrittr,
checkmate,
coda’
```
This commit should fix the issue by first splitting with respect to `,` or `, ` and then, after combining different fields, removing line breaks.

 
