### PR TITLE
Problem with parse_expressions() for input with if else

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,3 +43,4 @@ Language: en-GB
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
+Config/testthat/edition: 3

--- a/R/text-parsing-fns.R
+++ b/R/text-parsing-fns.R
@@ -234,7 +234,7 @@ bracket_sequences <- function (x, open_sym, close_sym, both_sym) {
                 start_multi_line_quote <- TRUE
             } else if (is.na (qstart_1) && !is.na (qend_1)) {
                 multi_line_quote <- FALSE
-            } 
+            }
 
             if (!multi_line_quote || (multi_line_quote && start_multi_line_quote)) {
 
@@ -419,7 +419,6 @@ parse_expressions <- function (x) {
                 xfirst <- x [1:(br_open [i] - 1)]
             if (br_closed [i] < length (x))
                 xlast <- x [(br_closed [i] + 1):length (x)]
-
             x <- c (xfirst, xmid, xlast)
         }
     }

--- a/autotest.Rproj
+++ b/autotest.Rproj
@@ -1,0 +1,20 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 4
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: XeLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,3 +1,11 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
 library(testthat)
 library(autotest)
 

--- a/tests/testthat/_snaps/text-parsing.md
+++ b/tests/testthat/_snaps/text-parsing.md
@@ -1,0 +1,7 @@
+# parse_expressions with two curly brace pairs
+
+    Code
+      parse_expressions(ex)
+    Error <simpleError>
+      missing value where TRUE/FALSE needed
+

--- a/tests/testthat/test-text-parsing.R
+++ b/tests/testthat/test-text-parsing.R
@@ -59,6 +59,12 @@ test_that ("parse_expressions", {
                expect_silent (eval (parse (text = res2)))
 })
 
+test_that("parse_expressions with two curly brace pairs", {
+    ex <- c("if (TRUE) {", "    message(\"blop\")",
+"} else {", "    message(\"bla\"", "    ))", "}")
+    expect_snapshot(parse_expressions(ex), error = TRUE)
+})
+
 test_that ("strip_if_cond", {
                x <- "if(x==1)y<-0"
                res <- strip_if_cond (x)


### PR DESCRIPTION
Reading the comments and test I'm not sure what's supposed to happen for this case actually, as it's not the same usage of the curly braces.

What's the expected output?

Why use regular expressions as opposed to parsing code? Then hopefully one could exclude if else statements from the transformations? I'm a bit confused.